### PR TITLE
Fortify

### DIFF
--- a/vars/fortifyScan.groovy
+++ b/vars/fortifyScan.groovy
@@ -48,7 +48,7 @@ def call(body) {
           sh "${translateCmd}"
           def fortifyScanResults = "target/fortify-${config.projname}-scan.fpr"
 
-          sh "sourceanalyzer -b ${config.projname} -scan -f ${fortifyScanResults} -format fpr"
+          //sh "sourceanalyzer -b ${config.projname} -scan -f ${fortifyScanResults} -format fpr"
 
           // -- Check if a fortifyScan was generated, and if it was, then use the report generator to convert
           //    it to a pdf

--- a/vars/fortifyScan.groovy
+++ b/vars/fortifyScan.groovy
@@ -56,7 +56,7 @@ def call(body) {
           def fprFile = new File("${fortifyScanResults}")
           if(fileExists("${fortifyScanResults}")) {
             sh "ReportGenerator -format pdf -f target/fortify-${config.projname}-scan.pdf -source target/fortify-${config.projname}-scan.fpr"
-            archive "target/fortify-${config.projname}-scan.xml"
+            archive "target/fortify-${config.projname}-scan.pdf"
           } else {
             print "Fortify code report ${currDir}/${fortifyScanResults} not found. Skipping the report generator..."
           }

--- a/vars/fortifyScan.groovy
+++ b/vars/fortifyScan.groovy
@@ -47,7 +47,7 @@ def call(body) {
           sh "sourceanalyzer -b ${config.projname} -clean"
           sh "${translateCmd}"
           sh "sourceanalyzer -b ${config.projname} -scan -f target/fortify-${config.projname}-scan.fpr -format fpr"
-          sh "ReportGenerator -format xml -f target/fortify-${config.projname}-scan.xml -source target/fortify-${config.projname}-scan.fpr"
+          sh "ReportGenerator -format pdf -f target/fortify-${config.projname}-scan.pdf -source target/fortify-${config.projname}-scan.fpr"
           archive "target/fortify-${config.projname}-scan.xml"
       }
 

--- a/vars/fortifyScan.groovy
+++ b/vars/fortifyScan.groovy
@@ -53,7 +53,7 @@ def call(body) {
           // -- Check if a fortifyScan was generated, and if it was, then use the report generator to convert
           //    it to a pdf
           def currDir = pwd(tmp: false)
-          def fprFile = new File("${currDir}/${fortifyScanResults}")
+          def fprFile = new File("file:/${currDir}/${fortifyScanResults}")
           if(fprFile.exists()) {
             sh "ReportGenerator -format pdf -f target/fortify-${config.projname}-scan.pdf -source target/fortify-${config.projname}-scan.fpr"
             archive "target/fortify-${config.projname}-scan.xml"

--- a/vars/fortifyScan.groovy
+++ b/vars/fortifyScan.groovy
@@ -48,7 +48,7 @@ def call(body) {
           sh "${translateCmd}"
           def fortifyScanResults = "target/fortify-${config.projname}-scan.fpr"
 
-          //sh "sourceanalyzer -b ${config.projname} -scan -f ${fortifyScanResults} -format fpr"
+          sh "sourceanalyzer -b ${config.projname} -scan -f ${fortifyScanResults} -format fpr"
 
           // -- Check if a fortifyScan was generated, and if it was, then use the report generator to convert
           //    it to a pdf

--- a/vars/fortifyScan.groovy
+++ b/vars/fortifyScan.groovy
@@ -52,8 +52,6 @@ def call(body) {
 
           // -- Check if a fortifyScan was generated, and if it was, then use the report generator to convert
           //    it to a pdf
-          def currDir = pwd(tmp: false)
-          def fprFile = new File("${fortifyScanResults}")
           if(fileExists("${fortifyScanResults}")) {
             sh "ReportGenerator -format pdf -f target/fortify-${config.projname}-scan.pdf -source target/fortify-${config.projname}-scan.fpr"
             archive "target/fortify-${config.projname}-scan.pdf"

--- a/vars/fortifyScan.groovy
+++ b/vars/fortifyScan.groovy
@@ -52,7 +52,8 @@ def call(body) {
 
           // -- Check if a fortifyScan was generated, and if it was, then use the report generator to convert
           //    it to a pdf
-          def fprFile = new File(fortifyScanResults)
+          def currDir = pwd(tmp: false)
+          def fprFile = new File("${currDir}/${fortifyScanResults}")
           if(fprFile.exists()) {
             sh "ReportGenerator -format pdf -f target/fortify-${config.projname}-scan.pdf -source target/fortify-${config.projname}-scan.fpr"
             archive "target/fortify-${config.projname}-scan.xml"

--- a/vars/fortifyScan.groovy
+++ b/vars/fortifyScan.groovy
@@ -10,7 +10,7 @@ def call(body) {
   }
 
   if (config.projname == null) {
-      config.projname = "${env.JOB_NAME}"
+      config.projname = "${env.JOB_BASE_NAME}"
   }
 
 
@@ -53,7 +53,7 @@ def call(body) {
           // -- Check if a fortifyScan was generated, and if it was, then use the report generator to convert
           //    it to a pdf
           def currDir = pwd(tmp: false)
-          def fprFile = new File("file:/${currDir}/${fortifyScanResults}")
+          def fprFile = new File("file://${currDir}/${fortifyScanResults}")
           if(fprFile.exists()) {
             sh "ReportGenerator -format pdf -f target/fortify-${config.projname}-scan.pdf -source target/fortify-${config.projname}-scan.fpr"
             archive "target/fortify-${config.projname}-scan.xml"

--- a/vars/fortifyScan.groovy
+++ b/vars/fortifyScan.groovy
@@ -46,9 +46,19 @@ def call(body) {
           sh "${mvnCmd} dependency:resolve"
           sh "sourceanalyzer -b ${config.projname} -clean"
           sh "${translateCmd}"
-          sh "sourceanalyzer -b ${config.projname} -scan -f target/fortify-${config.projname}-scan.fpr -format fpr"
-          sh "ReportGenerator -format pdf -f target/fortify-${config.projname}-scan.pdf -source target/fortify-${config.projname}-scan.fpr"
-          archive "target/fortify-${config.projname}-scan.xml"
+          def fortifyScanResults = "target/fortify-${config.projname}-scan.fpr"
+
+          sh "sourceanalyzer -b ${config.projname} -scan -f ${fortifyScanResults} -format fpr"
+
+          // -- Check if a fortifyScan was generated, and if it was, then use the report generator to convert
+          //    it to a pdf
+          def fprFile = new File(fortifyScanResults)
+          if(fprFile.exists()) {
+            sh "ReportGenerator -format pdf -f target/fortify-${config.projname}-scan.pdf -source target/fortify-${config.projname}-scan.fpr"
+            archive "target/fortify-${config.projname}-scan.xml"
+          }
+
+
       }
 
     }

--- a/vars/fortifyScan.groovy
+++ b/vars/fortifyScan.groovy
@@ -53,8 +53,8 @@ def call(body) {
           // -- Check if a fortifyScan was generated, and if it was, then use the report generator to convert
           //    it to a pdf
           def currDir = pwd(tmp: false)
-          def fprFile = new File("file://${currDir}/${fortifyScanResults}")
-          if(fprFile.exists()) {
+          def fprFile = new File("${fortifyScanResults}")
+          if(fileExists(fprFile)) {
             sh "ReportGenerator -format pdf -f target/fortify-${config.projname}-scan.pdf -source target/fortify-${config.projname}-scan.fpr"
             archive "target/fortify-${config.projname}-scan.xml"
           } else {

--- a/vars/fortifyScan.groovy
+++ b/vars/fortifyScan.groovy
@@ -54,7 +54,7 @@ def call(body) {
           //    it to a pdf
           def currDir = pwd(tmp: false)
           def fprFile = new File("${fortifyScanResults}")
-          if(fileExists(fprFile)) {
+          if(fileExists("${fortifyScanResults}")) {
             sh "ReportGenerator -format pdf -f target/fortify-${config.projname}-scan.pdf -source target/fortify-${config.projname}-scan.fpr"
             archive "target/fortify-${config.projname}-scan.xml"
           } else {

--- a/vars/fortifyScan.groovy
+++ b/vars/fortifyScan.groovy
@@ -57,6 +57,8 @@ def call(body) {
           if(fprFile.exists()) {
             sh "ReportGenerator -format pdf -f target/fortify-${config.projname}-scan.pdf -source target/fortify-${config.projname}-scan.fpr"
             archive "target/fortify-${config.projname}-scan.xml"
+          } else {
+            print "Fortify code report ${currDir}/${fortifyScanResults} not found. Skipping the report generator..."
           }
 
 

--- a/vars/mavenBuild.groovy
+++ b/vars/mavenBuild.groovy
@@ -54,9 +54,6 @@ def call(body) {
             try {
                 sh "${mvnCmd} package"
 
-                //TODO: Build mba files that fortify can use to perform scans, so we won't have compiler errors in the fortify build
-                //sh "${mvnCmd} clean install com.fortify.ps.maven.plugin:sca-maven-plugin:translate -Dfortify.sca.buildId=${env.JOB_NAME} -Dmaven.test.skip=true"
-
                 // Stash everything so can build on the fortify-sca agent
                 stash name: 'packaged'
             } finally {


### PR DESCRIPTION
- Fixes builds by using JOB_BASE_NAME instead of JOB_NAME
- Fixes partner jars by checking if *.fpr file exists before generating a report
- Takes out the unneeded TODO
- Archives a human-readable pdf instead of an xml 